### PR TITLE
fix: pin `clap` version to exact one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 exclude = [".*", "rust-toolchain", "rustfmt.toml", "release.toml"]
 
 [dependencies]
-clap = "3.0.0-beta.5"
+clap = "=3.0.0-beta.5"
 fncmd-impl = { path = "impl", version = "1.0.1" }
 
 [workspace]


### PR DESCRIPTION
As a temporary workaround, this prevents automatic upgrades of `clap` which can cause a breaking behavior.