### PR TITLE
fix: suppress unused attributes warning for subcommands

### DIFF
--- a/impl/src/models/fncmd.rs
+++ b/impl/src/models/fncmd.rs
@@ -135,6 +135,7 @@ impl ToTokens for Fncmd {
 					parse_str(&format!(r#""{}""#, path.to_str().unwrap())).unwrap();
 				let import = quote! {
 					#[path = #path_str]
+					#[allow(unused_attributes)]
 					mod #mod_name;
 				};
 				let enumitem = quote! {


### PR DESCRIPTION
Fixes the bug that unstable feature gates (i.e. `#![feature(...)]`) in subcommand binary files are reported as `unused_attributes` incorrectly, regardless of their usage.