### PR TITLE
fix: fix condition to collect subcommands with fully qualified macro path

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -74,7 +74,11 @@ pub fn fncmd(attr: TokenStream, item: TokenStream) -> TokenStream {
 							&& function
 								.attrs
 								.iter()
-								.any(|attr| attr.path.is_ident("fncmd"))
+								.any(|attr| {
+									// `#[fncmd::fncmd]` or `#[fncmd]`
+									attr.path.segments.len() <= 2
+									&& attr.path.segments.iter().all(|segment| segment.ident == "fncmd")
+								})
 					})
 					// If none of them are valid, just skip the file
 					.map(|function| {


### PR DESCRIPTION
Subcommands may have two patterns: `#[fncmd::fncmd]` and `#[fncmd]`.