### PR TITLE
fix: handle exotic main macros correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [".*", "rust-toolchain", "rustfmt.toml", "release.toml", "justfile"]
 [dependencies]
 clap = { version = "3.0.7", features = ["derive"] }
 fncmd-impl = { path = "impl", version = "=1.2.2" }
+once_cell = "1.9.0"
 
 [workspace]
 members = ["impl"]

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ src
 
 ## Use with exotic attribute macros
 
-Sometimes you may want to transform the `main` function with another attribute macro such as `#[tokio::main]`. In such case you have to put `#[fncmd]` at the outmost level:
+Sometimes you may want to transform the `main` function with another attribute macro such as `#[tokio::main]` and `#[async_std::main]`. In such case you have to put `#[fncmd]` at the outmost level:
 
 ```rs
 /// Description of the command line tool
@@ -177,7 +177,7 @@ pub async fn main(hello: String) -> anyhow::Result<()> {
 }
 ```
 
-This is because Rust requires procedural macros to produce legal code *for each* macroexpansion. If you put `#[tokio::main]` before, then it outputs the code preserving the parameters as is, while `main` funtions with parameters are not legal in Rust. To workaround this, `#[fncmd]` detects other attributes (this is only possible when the others are present after `#[fncmd]`), and if any, remove the parameters temporarily and save them into an internal field for later use, so that the others expand into legal code.
+This is because ~~Rust requires procedural macros to produce legal code *for each* macroexpansion~~Sorry this is wrong, it's not Rust but the macros like `#[tokio::main]` *do* some assertions on their own, so we need to feed them a well-mannered version of `main` function, e.g. removing parameters.
 
 Position of the doc comment doesn't matter.
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -118,21 +118,3 @@ pub fn fncmd(attr: TokenStream, item: TokenStream) -> TokenStream {
 	let item = parse_macro_input!(item as ItemFn);
 	Fncmd::parse(self_bin_name, self_version, attr, item, subcmds).into()
 }
-
-#[proc_macro_attribute]
-#[proc_macro_error]
-pub fn __inject_params(attr: TokenStream, item: TokenStream) -> TokenStream {
-	use darling::FromMeta;
-
-	#[derive(Debug, Default, FromMeta)]
-	#[darling(default)]
-	pub struct Attr {
-		__params: Punctuated<FnArg, Comma>,
-	}
-
-	let attr = parse_macro_input!(attr as AttributeArgs);
-	let attr = Attr::from_list(&attr).unwrap();
-
-	dbg!(attr);
-	quote!().into()
-}

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -8,11 +8,8 @@ use cargo_metadata::MetadataCommand;
 use darling::FromMeta;
 use proc_macro::{Span, TokenStream};
 use proc_macro_error::proc_macro_error;
-use quote::quote;
-use syn::punctuated::Punctuated;
-use syn::token::Comma;
 use syn::visit::Visit;
-use syn::{parse_file, parse_macro_input, AttributeArgs, FnArg, ItemFn};
+use syn::{parse_file, parse_macro_input, AttributeArgs, ItemFn};
 
 mod models;
 use models::*;

--- a/impl/src/models/fncmd_attr.rs
+++ b/impl/src/models/fncmd_attr.rs
@@ -2,4 +2,6 @@ use darling::FromMeta;
 
 #[derive(Debug, Default, FromMeta)]
 #[darling(default)]
-pub struct FncmdAttr {}
+pub struct FncmdAttr {
+	// Empty for now, but it's here for future use
+}

--- a/impl/src/models/fncmd_attr.rs
+++ b/impl/src/models/fncmd_attr.rs
@@ -1,17 +1,5 @@
 use darling::FromMeta;
-use syn::{parse_str, punctuated::Punctuated, token::Comma, FnArg, ItemFn};
 
 #[derive(Debug, Default, FromMeta)]
 #[darling(default)]
-pub struct FncmdAttr {
-	__item_fn: Option<String>,
-}
-
-impl FncmdAttr {
-	pub fn args(&self) -> Option<Punctuated<FnArg, Comma>> {
-		self.__item_fn
-			.as_ref()
-			.and_then(|string| parse_str::<ItemFn>(string).ok())
-			.map(|item| item.sig.inputs)
-	}
-}
+pub struct FncmdAttr {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
 
 pub use fncmd_impl::fncmd;
 
-#[doc(hidden)]
-pub use fncmd_impl::__inject_params;
-
 mod exit_code;
 #[doc(hidden)]
 pub use exit_code::{ExitCode, IntoExitCode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,15 @@
 
 pub use fncmd_impl::fncmd;
 
+#[doc(hidden)]
+pub use fncmd_impl::__inject_params;
+
 mod exit_code;
 #[doc(hidden)]
 pub use exit_code::{ExitCode, IntoExitCode};
 
 #[doc(hidden)]
 pub use clap;
+
+#[doc(hidden)]
+pub use once_cell::sync::Lazy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,8 @@
 pub use fncmd_impl::fncmd;
 
 mod exit_code;
-
 #[doc(hidden)]
-pub use exit_code::ExitCode;
-#[doc(hidden)]
-pub use exit_code::IntoExitCode;
-
-mod termination;
-
-#[doc(hidden)]
-pub use termination::Termination;
+pub use exit_code::{ExitCode, IntoExitCode};
 
 #[doc(hidden)]
 pub use clap;

--- a/src/termination.rs
+++ b/src/termination.rs
@@ -1,3 +1,0 @@
-/// Without this alias, users have to manually enable
-/// `#![feature(termination_trait_lib)]`
-pub trait Termination = std::process::Termination;


### PR DESCRIPTION
This should extend compatibility with foreign macros. At least we can confirm two async runtimes work: `#[tokio::main]` and `#[async_std::main]`.