### PR TITLE
fix: follow upstream change of `std::process::Termination`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,4 +195,4 @@ That's why `fncmd` states “opinionated”. Showing authors on the help will si
 
 The way it automatically determines which targets are subcommands or not requires the `#[fncmd]` macro itself to know the name of the attached target, and thus the path of the file at which it has been called. This can be achieved by [`Span::source_file`](https://doc.rust-lang.org/proc_macro/struct.Span.html#method.source_file), which is behind an unstable feature flag `proc_macro_span`.
 
-Additionally, in order to allow users to use different return types for subcommand functions, it uses [`std::process::Termination`](https://doc.rust-lang.org/std/process/trait.Termination.html) trait internally, which is behind `termination_trait_lib`.
+Additionally, in order to allow users to use different return types for subcommand functions, it uses [`std::process::Termination`](https://doc.rust-lang.org/std/process/trait.Termination.html) trait internally, which is behind `termination_trait_lib` and `process_exitcode_placeholder`.

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -1,6 +1,6 @@
 /// An intermediate type to abstract over various return types from subcommand
 /// functions.
-pub struct ExitCode(i32);
+pub struct ExitCode(std::process::ExitCode);
 
 pub trait IntoExitCode {
 	fn into_exit_code(self) -> ExitCode;
@@ -13,7 +13,7 @@ impl<T: std::process::Termination> IntoExitCode for T {
 }
 
 impl std::process::Termination for ExitCode {
-	fn report(self) -> i32 {
+	fn report(self) -> std::process::ExitCode {
 		self.0
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(termination_trait_lib, trait_alias)]
+#![feature(termination_trait_lib, trait_alias, process_exitcode_placeholder)]
 #![doc = include_str!("../README.md")]
 
 pub use fncmd_impl::fncmd;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(termination_trait_lib, trait_alias, process_exitcode_placeholder)]
+#![feature(termination_trait_lib, process_exitcode_placeholder)]
 #![doc = include_str!("../README.md")]
 
 pub use fncmd_impl::fncmd;


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/93442

Noticed this by seeing documentation build fails: https://docs.rs/crate/fncmd/1.2.3/builds/506753