### PR TITLE
Feature "termination_trait_lib" is now stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(termination_trait_lib, process_exitcode_placeholder)]
 #![doc = include_str!("../README.md")]
 
 pub use fncmd_impl::fncmd;


### PR DESCRIPTION
fncmd doesn't compile on latest nightly anymore due to termination_trait_lib now being stable.