### PR TITLE
build!: upgrade `clap` to 4.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ doctest = false
 members = ["impl"]
 
 [dependencies]
-clap = { version = "3.0.7", features = ["derive"] }
+clap = { version = "4.2.4", features = ["derive"] }
 fncmd-impl = { path = "impl", version = "=1.3.1" }
 once_cell = "1.9.0"

--- a/README.md
+++ b/README.md
@@ -50,19 +50,18 @@ pub fn main(
 
 That's all, and now you got a command line program with options handled by `clap`. With above code, the help message will be like below:
 
-```plaintext
-crate-name 0.1.0
-
+```console
+$ crate-name --help
 Description of the command line tool
 
-USAGE:
-    crate-name [OPTIONS] --foo <FOO>
+Usage: crate-name [OPTIONS] --foo <FOO>
 
-OPTIONS:
-    -b, --bar <BAR>    Argument bar
-    -f, --foo <FOO>    Argument foo
-    -h, --help         Print help information
-    -V, --version      Print version information
+Options:
+  -f, --foo <FOO>  Argument foo
+  -b, --bar <BAR>  Argument bar
+  -h, --help       Print help
+  -V, --version    Print version
+
 ```
 
 The name and the version of your crate are automatically inferred from Cargo metadata.
@@ -151,7 +150,7 @@ src
 
 Sometimes you may want to transform the `main` function with another attribute macro such as `#[tokio::main]` and `#[async_std::main]`. In such case you have to put `#[fncmd]` at the outmost level:
 
-```rs
+```rust
 /// Description of the command line tool
 #[fncmd]
 #[tokio::main]
@@ -162,7 +161,7 @@ pub async fn main(hello: String) -> anyhow::Result<()> {
 
 But not:
 
-```rs
+```rust
 /// Description of the command line tool
 #[tokio::main]
 #[fncmd]

--- a/examples/example-basic/README.md
+++ b/examples/example-basic/README.md
@@ -1,32 +1,26 @@
 ```console
 $ example-basic
 ? 2
-error: The following required arguments were not provided:
-    <GREETING>
+error: the following required arguments were not provided:
+  <GREETING>
 
-USAGE:
-    example-basic [OPTIONS] <GREETING> [NAME]
+Usage: example-basic <GREETING> [NAME]
 
-For more information try --help
+For more information, try '--help'.
 
 ```
 
 ```console
 $ example-basic --help
-example-basic 0.0.0
-Prints greeting message
+Description of the command line tool
 
-USAGE:
-    example-basic [OPTIONS] <GREETING> [NAME]
+Usage: crate-name [OPTIONS] --foo <FOO>
 
-ARGS:
-    <GREETING>    Greeting message
-    <NAME>        Name of someone to greet
-
-OPTIONS:
-        --bang       Whether to use “!” instead of “.” at the end of the message
-    -h, --help       Print help information
-    -V, --version    Print version information
+Options:
+  -f, --foo <FOO>  Argument foo
+  -b, --bar <BAR>  Argument bar
+  -h, --help       Print help
+  -V, --version    Print version
 
 ```
 

--- a/examples/example-subcmds/README.md
+++ b/examples/example-subcmds/README.md
@@ -6,18 +6,15 @@ Top-level command is called.
 
 ```console
 $ example-subcmds --help
-example-subcmds 0.0.0
+Usage: example-subcmds [COMMAND]
 
-USAGE:
-    example-subcmds [SUBCOMMAND]
+Commands:
+  child  
+  help   Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    child    
-    help     Print this message or the help of the given subcommand(s)
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
 
 ```
 
@@ -36,12 +33,11 @@ Two-level-deep subcommand is called.
 ```console
 $ example-subcmds orphan
 ? 2
-error: Found argument 'orphan' which wasn't expected, or isn't valid in this context
+error: unrecognized subcommand 'orphan'
 
-USAGE:
-    example-subcmds [SUBCOMMAND]
+Usage: example-subcmds [COMMAND]
 
-For more information try --help
+For more information, try '--help'.
 
 ```
 

--- a/examples/example-subcmdsflat/README.md
+++ b/examples/example-subcmdsflat/README.md
@@ -6,18 +6,15 @@ Top-level command is called.
 
 ```console
 $ example-subcmdsflat --help
-example-subcmdsflat 0.0.0
+Usage: example-subcmdsflat [COMMAND]
 
-USAGE:
-    example-subcmdsflat [SUBCOMMAND]
+Commands:
+  child  
+  help   Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    child    
-    help     Print this message or the help of the given subcommand(s)
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
 
 ```
 
@@ -36,12 +33,11 @@ Two-level-deep subcommand is called.
 ```console
 $ example-subcmdsflat orphan
 ? 2
-error: Found argument 'orphan' which wasn't expected, or isn't valid in this context
+error: unrecognized subcommand 'orphan'
 
-USAGE:
-    example-subcmdsflat [SUBCOMMAND]
+Usage: example-subcmdsflat [COMMAND]
 
-For more information try --help
+For more information, try '--help'.
 
 ```
 


### PR DESCRIPTION
Upgraded from 3.0.7. It seems to be working without any changes to our macros, but by definition it may contain some breaking changes in the reexported stuff even we don't notice at this time, so we'd also mark this upgrade as a breaking change.